### PR TITLE
Recording upload option for ScreenApp + Recording configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 NODE_ENV=development
 SCREENAPP_AUTH_BASE_URL_V2=http://host.docker.internal:8081/v2
+
+# Meeting recording configuration
 MAX_RECORDING_DURATION_MINUTES=180
+MEETING_INACTIVITY_MINUTES=15
+INACTIVITY_DETECTION_START_DELAY_MINUTES=5
 
 # GCP bucket configuration for uploading debugging screenshots
 GCP_ACCESS_KEY_ID=

--- a/README.md
+++ b/README.md
@@ -325,7 +325,9 @@ S3_USE_MINIO_COMPATIBILITY=true
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MAX_RECORDING_DURATION_MINUTES` | Maximum recording duration in minutes | `60` |
+| `MAX_RECORDING_DURATION_MINUTES` | Maximum recording duration in minutes | `180` |
+| `MEETING_INACTIVITY_MINUTES` | Continuous inactivity duration after which the bot will end meeting recording | `1` |
+| `INACTIVITY_DETECTION_START_DELAY_MINUTES` | Initial grace period at the start of recording before inactivity detection begins | `1` |
 | `PORT` | Server port | `3000` |
 | `NODE_ENV` | Environment mode | `development` |
 | `UPLOADER_FILE_EXTENSION` | Final recording file extension (e.g., .mkv, .webm) | `.webm` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,8 +57,8 @@ export default {
     Number(process.env.MAX_RECORDING_DURATION_MINUTES) :
     180, // There's an upper limit on meeting duration 3 hours 
   chromeExecutablePath: '/usr/bin/google-chrome', // We use Google Chrome with Playwright for recording
-  inactivityLimit: 0.5,
-  activateInactivityDetectionAfter: 0.5,
+  inactivityLimit: process.env.MEETING_INACTIVITY_MINUTES ? Number(process.env.MEETING_INACTIVITY_MINUTES) : 1,
+  activateInactivityDetectionAfter: process.env.INACTIVITY_DETECTION_START_DELAY_MINUTES ? Number(process.env.INACTIVITY_DETECTION_START_DELAY_MINUTES) :  1,
   serviceKey: process.env.SCREENAPP_BACKEND_SERVICE_API_KEY,
   joinWaitTime: 10,
   miscStorageBucket: process.env.GCP_MISC_BUCKET,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { UploadType } from './types';
+import { UploaderType } from './types';
 dotenv.config();
 
 const ENVIRONMENTS = [
@@ -78,5 +78,5 @@ export default {
     bucket: process.env.S3_BUCKET_NAME,
     forcePathStyle: process.env.S3_USE_MINIO_COMPATIBILITY === 'true',
   },
-  uploadType: process.env.UPLOAD_TYPE ? (process.env.UPLOAD_TYPE as UploadType) : 's3' as UploadType,
+  uploaderType: process.env.UPLOADER_TYPE ? (process.env.UPLOADER_TYPE as UploaderType) : 's3' as UploaderType,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,4 +197,4 @@ export const logCategories: {
 export type LogCategory = typeof logCategories[number]['category'];
 export type LogSubCategory<C extends LogCategory> = (typeof logCategories[number] & { category: C })['subCategory'][number];
 
-export type UploadType = 'screenapp' | 's3';
+export type UploaderType = 'screenapp' | 's3';


### PR DESCRIPTION
## Description


1. Fix upload compatibility with ScreenApp platform
2. Allow for configuration options for inactivity detection feature

| Variable | Description | Default |
|----------|-------------|---------|
| `MEETING_INACTIVITY_MINUTES` | Continuous inactivity duration after which the bot will end meeting recording | `1` |
| `INACTIVITY_DETECTION_START_DELAY_MINUTES` | Initial grace period at the start of recording before inactivity detection begins | `1` |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

