### PR TITLE
Chore/removing retrying after lobby timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,14 @@ AUTH_BASE_URL_V2=http://host.docker.internal:8081/v2
 
 # Meeting recording configuration
 MAX_RECORDING_DURATION_MINUTES=180
-MEETING_INACTIVITY_MINUTES=15
+# Silence detection timeout in minutes (how long to wait before ending due to inactivity)
+MEETING_INACTIVITY_MINUTES=2
 INACTIVITY_DETECTION_START_DELAY_MINUTES=5
+# How long to wait at lobby before timing out (in minutes)
+JOIN_WAIT_TIME_MINUTES=2
+# Number of retries for transient errors (WaitingAtLobbyRetryError never retries)
+# RETRY_COUNT=2 means: 1 initial attempt + 2 retries = 3 total attempts
+RETRY_COUNT=2
 
 # GCP bucket configuration for uploading debugging screenshots
 GCP_ACCESS_KEY_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meeting-bot",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meeting-bot",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.787.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meeting-bot",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Run meeting bots for Google Meet, Microsoft Teams and Zoom",
   "main": "index.js",
   "license": "MIT",

--- a/src/bots/GoogleMeetBot.ts
+++ b/src/bots/GoogleMeetBot.ts
@@ -344,7 +344,8 @@ export class GoogleMeetBot extends MeetBotBase {
 
         this._logger.error('Cant finish wait at the lobby check', { userDenied, waitingAtLobbySuccess, bodyText });
 
-        throw new WaitingAtLobbyRetryError('Google Meet bot could not enter the meeting...', bodyText ?? '', !userDenied, 2);
+        // Don't retry lobby errors - if user doesn't admit bot, retrying won't help
+        throw new WaitingAtLobbyRetryError('Google Meet bot could not enter the meeting...', bodyText ?? '', false, 0);
       }
     } catch(lobbyError) {
       this._logger.info('Closing the browser on error...', lobbyError);

--- a/src/bots/MicrosoftTeamsBot.ts
+++ b/src/bots/MicrosoftTeamsBot.ts
@@ -306,8 +306,9 @@ export class MicrosoftTeamsBot extends MeetBotBase {
 
       this._logger.error('Closing the browser on error...', error);
       await this.page.context().browser()?.close();
-      
-      throw new WaitingAtLobbyRetryError('Microsoft Teams Meeting bot could not enter the meeting...', bodyText ?? '', !userDenied, 2);
+
+      // Don't retry lobby errors - if user doesn't admit bot, retrying won't help
+      throw new WaitingAtLobbyRetryError('Microsoft Teams Meeting bot could not enter the meeting...', bodyText ?? '', false, 0);
     }
 
     pushState('joined');
@@ -508,10 +509,8 @@ export class MicrosoftTeamsBot extends MeetBotBase {
       });
 
       // Start audio silence detection (runs in parallel with participant detection)
-      // inactivityLimit is in milliseconds (default 2 minutes = 120000ms)
-      const inactivityLimitMs = config.inactivityLimit && config.inactivityLimit > 1000
-        ? config.inactivityLimit
-        : 120000; // Default to 2 minutes
+      // Convert inactivityLimit from minutes to milliseconds
+      const inactivityLimitMs = config.inactivityLimit * 60 * 1000;
 
       const monitorAudioSilence = async () => {
         try {

--- a/src/bots/ZoomBot.ts
+++ b/src/bots/ZoomBot.ts
@@ -293,7 +293,7 @@ export class ZoomBot extends BotBase {
     // Wait in waiting room
     try {
       const wanderingTime = config.joinWaitTime * 60 * 1000; // Give some time to be let in
-      
+
       let waitTimeout: NodeJS.Timeout;
       let waitInterval: NodeJS.Timeout;
       const waitAtLobbyPromise = new Promise<boolean>((resolveMe) => {
@@ -355,7 +355,8 @@ export class ZoomBot extends BotBase {
 
         this._logger.error('Cant finish wait at the lobby check', { userDenied, waitingAtLobbySuccess: joined, bodyText });
 
-        throw new WaitingAtLobbyRetryError('Zoom bot could not enter the meeting...', bodyText ?? '', !userDenied, 2);
+        // Don't retry lobby errors - if user doesn't admit bot, retrying won't help
+        throw new WaitingAtLobbyRetryError('Zoom bot could not enter the meeting...', bodyText ?? '', false, 0);
       }
 
       this._logger.info('Bot is entering the meeting after wait room...');

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,7 +60,9 @@ export default {
   inactivityLimit: process.env.MEETING_INACTIVITY_MINUTES ? Number(process.env.MEETING_INACTIVITY_MINUTES) : 1,
   activateInactivityDetectionAfter: process.env.INACTIVITY_DETECTION_START_DELAY_MINUTES ? Number(process.env.INACTIVITY_DETECTION_START_DELAY_MINUTES) :  1,
   serviceKey: process.env.SCREENAPP_BACKEND_SERVICE_API_KEY,
-  joinWaitTime: 10,
+  joinWaitTime: process.env.JOIN_WAIT_TIME_MINUTES ? Number(process.env.JOIN_WAIT_TIME_MINUTES) : 10,
+  // Number of retries for transient errors (not applied to WaitingAtLobbyRetryError)
+  retryCount: process.env.RETRY_COUNT ? Number(process.env.RETRY_COUNT) : 2,
   miscStorageBucket: process.env.GCP_MISC_BUCKET,
   miscStorageFolder: process.env.GCP_MISC_BUCKET_FOLDER ? process.env.GCP_MISC_BUCKET_FOLDER : 'meeting-bot',
   region: process.env.GCP_DEFAULT_REGION,


### PR DESCRIPTION
Fix lobby retry logic and add configurable retry settings

Fixed WaitingAtLobbyRetryError to never retry (reduces failure time from 20+ to 10 minutes). Added configurable RETRY_COUNT and JOIN_WAIT_TIME_MINUTES environment variables.