### PR TITLE
fix(meeting-bot): graceful shutdown on SIGTERM (Playwright handleSIGTERM)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 start.sh text eol=lf
+xvfb-run-wrapper text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ assets/screenshots
 /data
 debug-videos/
 .env.native
+
+# Local-only docker compose override for signal-handling testing — see compose.override.yml header
+compose.override.yml
+docker-compose.override.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meeting-bot",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Run meeting bots for Google Meet, Microsoft Teams and Zoom",
   "main": "index.js",
   "license": "MIT",

--- a/src/lib/chromium.ts
+++ b/src/lib/chromium.ts
@@ -111,6 +111,13 @@ async function createBrowserContext(url: string, correlationId: string, botType:
   const browser = await launchBrowserWithTimeout(
     async () => await chromium.launch({
       headless: false,
+      // Don't let Playwright install its own SIGTERM/SIGINT/SIGHUP handlers — they
+      // close the browser immediately when the node process receives a signal, which
+      // breaks our graceful shutdown (we want the in-flight recording to finish).
+      // The app explicitly calls browser.close() when the recording is done.
+      handleSIGINT: false,
+      handleSIGTERM: false,
+      handleSIGHUP: false,
       args: [
         ...browserArgs,
         ...displayArgs,

--- a/xvfb-run-wrapper
+++ b/xvfb-run-wrapper
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Forward SIGTERM to child processes
-trap 'echo "sending SIGABRT to child"; kill -SIGABRT "$child" 2>/dev/null' SIGTERM SIGINT
+# Forward SIGTERM to the node child so its graceful-shutdown handler runs.
+# We previously used SIGABRT to dodge Playwright auto-closing chrome on SIGTERM,
+# but Node doesn't reliably honor SIGABRT handlers. Playwright is now configured
+# with handleSIGTERM: false (see src/lib/chromium.ts), so SIGTERM is safe.
+trap 'echo "forwarding SIGTERM to child"; kill -SIGTERM "$child" 2>/dev/null' SIGTERM SIGINT
 
 # Set up PulseAudio runtime directory for non-root user
 export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}


### PR DESCRIPTION
  ---
  ## Summary
  Meeting-bot pods were hanging in Terminating for the full 3h grace period after SIGTERM.
   Root cause: `xvfb-run-wrapper` forwarded SIGTERM as SIGABRT (originally to dodge
  Playwright auto-closing chrome on SIGTERM) — but Node doesn't reliably catch SIGABRT, so
   graceful shutdown never ran. Pods kept consuming Redis jobs until SIGKILL.

  ## Fix
  - `chromium.launch({ handleSIGINT/TERM/HUP: false })` so Playwright stops killing chrome
   on signals.
  - Wrapper now forwards SIGTERM as SIGTERM. Node's existing SIGTERM handler in
  `src/index.ts` fires cleanly.
  - `.gitattributes` pins `xvfb-run-wrapper` to LF so Windows commits don't break the bash
   script in the Linux container.

  ---