### PR TITLE
fix(meeting-bot): detect participants via data-avatar-count for new Meet UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ debug-videos/
 
 # Local-only docker compose override for signal-handling testing — see compose.override.yml header
 compose.override.yml
+compose.override.yml.bak
 docker-compose.override.yml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meeting-bot",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Run meeting bots for Google Meet, Microsoft Teams and Zoom",
   "main": "index.js",
   "license": "MIT",

--- a/src/bots/GoogleMeetBot.ts
+++ b/src/bots/GoogleMeetBot.ts
@@ -548,7 +548,7 @@ export class GoogleMeetBot extends MeetBotBase {
         };
 
         async function startRecording() {
-          console.log('Will activate the inactivity detection after', activateInactivityDetectionAfter);
+          console.log('Will activate inactivity detection (participant + silence checks) after', activateInactivityDetectionAfter);
 
           // Check for the availability of the mediaDevices API
           if (!navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
@@ -652,6 +652,23 @@ export class GoogleMeetBot extends MeetBotBase {
             const re = /^[0-9]+$/;
 
             function getContributorsCount(): number | undefined {
+              // Method 0: Global search for [data-avatar-count] anywhere in DOM.
+              // In the current Google Meet UI (no visible "People" button in main controls),
+              // the participant count is shown as a badge next to the user's avatar in the
+              // top-right. The badge is a <span data-avatar-count="N"> not tied to any button.
+              // This is the most reliable signal — try it first before the legacy People-button hunt.
+              try {
+                const avatarBadge = document.querySelector('[data-avatar-count]');
+                if (avatarBadge) {
+                  const count = Number(avatarBadge.getAttribute('data-avatar-count'));
+                  if (!isNaN(count) && count > 0) {
+                    return count;
+                  }
+                }
+              } catch (e) {
+                console.log('Error reading global data-avatar-count:', e);
+              }
+
               function findPeopleButton() {
                 try {
                   // 1. Try to locate using attribute "starts with"
@@ -864,11 +881,18 @@ export class GoogleMeetBot extends MeetBotBase {
                   audioActivitySum += audioActivity;
                   totalChecks++;
 
-                  // Log silence detection status once per minute
+                  // Log silence detection status once per minute, including how close
+                  // we are to the inactivity-limit exit so it's clear when this would fire.
                   const now = Date.now();
                   if (now - lastActivityLogTime > 60000) {
                     const avgActivity = (audioActivitySum / totalChecks).toFixed(2);
-                    console.log('Silence detection check - Avg:', avgActivity, 'Current:', audioActivity.toFixed(2), 'Threshold:', silenceThreshold);
+                    const silentForSec = Math.floor(silenceDuration / 1000);
+                    const limitSec = Math.floor(inactivityLimit / 1000);
+                    const exitInSec = Math.max(0, limitSec - silentForSec);
+                    const status = audioActivity < silenceThreshold
+                      ? `silentFor: ${silentForSec}s of ${limitSec}s, will exit in ${exitInSec}s if silence continues`
+                      : 'audio active (counter reset)';
+                    console.log('Silence detection check - Avg:', avgActivity, 'Current:', audioActivity.toFixed(2), 'Threshold:', silenceThreshold, '|', status);
                     lastActivityLogTime = now;
                   }
 


### PR DESCRIPTION
## Summary
Google Meet's new minimal-controls UI no longer renders a `<button
aria-label="People - N joined">` in the bottom bar — the participant count
moved to a `<span data-avatar-count="N">` badge next to the user's avatar
in the top-right. Our 6 existing People-button selectors all failed, the
detection counter hit `maxDetectionFailures=10`, and the bot permanently
disabled lone-participant detection for the rest of the session. The bot
then relied only on `MEETING_INACTIVITY_MINUTES=10` silence-fallback, so it
 stayed in empty meetings for ~10 minutes after everyone left.

## Fix
Added Method 0 to `getContributorsCount` (`GoogleMeetBot.ts`): a global
`document.querySelector('[data-avatar-count]')` that runs before the legacy
 People-button hunt. The badge is present in the current Meet UI regardless
 of whether the bottom hover tray is expanded. Existing methods 1-6 stay as
 fallback for older UI variants.

## Drive-by log improvements
- "Will activate the inactivity detection after T" → "Will activate
inactivity detection (participant + silence checks) after T" — clarifies
that both detectors arm at this timestamp.
- Silence check log now appends `silentFor: Xs of Ys, will exit in Zs if
silence continues` (or `audio active (counter reset)`) so it's clear when
the bot is about to exit on silence-fallback.

## Test plan
- [ ] Bot joins a Meet, log shows `Participant detection check - Count: N`
matching the actual number of participants.
- [ ] When everyone leaves and the bot is alone, count drops to `1` → `if
(contributors < 2)` triggers → bot exits in seconds instead of waiting 10
min for silence-fallback.

## Known limitation (out of scope)
- If `data-avatar-count` is briefly missing during initial page load, the
existing "permanently disable after 10 failures" logic still triggers and
leaves the bot relying on silence-fallback only. Can address separately if
it bites.