### PR TITLE
fix(meeting-bot): don't rethrow Teams upload failure (causes meeting rejoin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meeting-bot",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Run meeting bots for Google Meet, Microsoft Teams and Zoom",
   "main": "index.js",
   "license": "MIT",

--- a/src/bots/MicrosoftTeamsBot.ts
+++ b/src/bots/MicrosoftTeamsBot.ts
@@ -49,9 +49,10 @@ export class MicrosoftTeamsBot extends MeetBotBase {
 
       if (_state.includes('finished') && !uploadResult) {
         _state.splice(_state.indexOf('finished'), 1, 'failed');
-        this._logger.error('Recording completed but upload failed', { botId, userId, teamId });
-        await patchBotStatus({ botId, eventId, provider: 'microsoft', status: _state, token: bearerToken }, this._logger);
-        throw new Error('Recording upload failed');
+        this._logger.error('Recording completed but upload failed; not throwing so JobStore does not rejoin the (now-ended) meeting', { botId, userId, teamId });
+        // Intentionally do NOT throw here — JobStore.executeTaskWithRetry would re-run
+        // the entire join+record+upload task, producing a second (garbage) recording on
+        // an already-ended meeting. The single upload failure is preferable to that.
       } else if (uploadResult) {
         this._logger.info('Recording and upload completed successfully', { botId, userId, teamId });
       }


### PR DESCRIPTION
## Summary
When the Microsoft Teams bot's upload step failed (e.g. transient 5xx, 401,
network blip), `MicrosoftTeamsBot.join` threw `'Recording upload failed'`.
`JobStore.executeTaskWithRetry` caught it and retried the **entire** task
— including `joinMeeting` — so the bot rejoined the (now-ended) meeting and
produced a garbage second recording on top of the lost upload.

Google and Zoom bots already handle this correctly (mark state failed,
don't throw). Microsoft was the outlier.

## Fix
Removed the `throw new Error('Recording upload failed')` in
`MicrosoftTeamsBot.join`. State is still spliced to `'failed'` and
`patchBotStatus` is called — same observable outcome — but no rethrow means
JobStore sees the task as complete and doesn't retry.

The duplicate `patchBotStatus` call inside the if-branch is also removed;
the outer call at the end of the try handles both success and failure paths
now (matching Google's pattern).

## Test plan
- [ ] Local: force a 401/5xx from the upload step (bad auth token works).
Verify single recording attempt, no rejoin, status patched as `'failed'`.
- [ ] Prod: on transient backend hiccups, bot no longer logs `Retry count:
1` followed by a second `Pre-warming: Opening browser` cycle.
