### PR TITLE
fix(meeting-bot): shutdown immediately if pod was marked for deletion during ContainerCreating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meeting-bot",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Run meeting bots for Google Meet, Microsoft Teams and Zoom",
   "main": "index.js",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import app, { redisConsumerService, setGracefulShutdown } from './app';
 import { globalJobStore } from './lib/globalJobStore';
 import messageBroker from './connect/messageBroker';
 import config from './config';
+import { isPodMarkedForDeletion } from './util/k8sLifecycle';
+import { loggerFactory } from './util/logger';
 
 const port = 3000;
 
@@ -14,6 +16,27 @@ const server = http.createServer(app);
 server.listen(port, () => {
   console.log(`Server is running on http://localhost:${port}`);
 });
+
+// Detect the "SIGTERM lost during ContainerCreating" race: if K8s marked us for deletion
+// before the container's PID 1 existed, the SIGTERM was silently dropped. Without this
+// check, the bot would run normally for the full terminationGracePeriodSeconds.
+//
+// 10s delay so kubelet has first chance to deliver SIGTERM via the normal path
+// (when it does work) — this check is the fallback for the broken case. Safe even
+// if SIGTERM also fires: initiateGracefulShutdown is idempotent (guards on shutdownInProgress).
+const startupLogger = loggerFactory('startup', 'system');
+setTimeout(() => {
+  isPodMarkedForDeletion(startupLogger)
+    .then((isDeleted) => {
+      if (isDeleted) {
+        console.log('Pod marked for deletion at startup — initiating graceful shutdown');
+        initiateGracefulShutdown();
+      }
+    })
+    .catch((err) => {
+      console.error('Startup pod-deletion check threw (continuing normal startup):', err);
+    });
+}, 10000);
 
 // Flag to prevent multiple shutdown attempts
 let shutdownInProgress = false;

--- a/src/util/k8sLifecycle.ts
+++ b/src/util/k8sLifecycle.ts
@@ -1,0 +1,68 @@
+import * as fs from 'fs';
+import * as https from 'https';
+import axios from 'axios';
+import { Logger } from 'winston';
+
+// Reads the bot's own pod metadata via the in-cluster K8s API to detect whether the
+// pod has already been marked for deletion before the container finished starting.
+//
+// Why this exists: when K8s sets a pod's deletionTimestamp while the container is still
+// in ContainerCreating (e.g. HPA scale-down during slow image pull, or rollout colliding
+// with an earlier deletion), kubelet sends SIGTERM to a not-yet-existing PID 1 and the
+// signal is silently dropped. kubelet does NOT re-send SIGTERM after the container starts,
+// so the bot then runs normally for the full terminationGracePeriodSeconds (3h) before
+// being SIGKILLed — picking up Redis jobs the whole time. This helper lets the bot detect
+// the situation at startup and trigger graceful shutdown itself.
+//
+// Fail-open: every error path returns false (proceed with normal startup). We only
+// true-positive when we're certain.
+
+const SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token';
+const SA_CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt';
+const K8S_API = 'https://kubernetes.default.svc';
+const REQUEST_TIMEOUT_MS = 5000;
+
+export async function isPodMarkedForDeletion(logger: Logger): Promise<boolean> {
+  const podName = process.env.POD_NAME;
+  const namespace = process.env.POD_NAMESPACE;
+
+  if (!podName || !namespace) {
+    logger.info('k8sLifecycle: skipping pod-deletion check (POD_NAME/POD_NAMESPACE not set — likely running outside K8s)');
+    return false;
+  }
+  if (!fs.existsSync(SA_TOKEN_PATH)) {
+    logger.info('k8sLifecycle: skipping pod-deletion check (no service account token mounted)');
+    return false;
+  }
+
+  try {
+    const token = fs.readFileSync(SA_TOKEN_PATH, 'utf-8').trim();
+    const ca = fs.readFileSync(SA_CA_PATH);
+    const url = `${K8S_API}/api/v1/namespaces/${namespace}/pods/${podName}`;
+
+    const resp = await axios.get(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      httpsAgent: new https.Agent({ ca }),
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+
+    const deletionTimestamp = resp.data?.metadata?.deletionTimestamp;
+    if (deletionTimestamp) {
+      logger.warn('k8sLifecycle: pod is already marked for deletion at startup — will trigger graceful shutdown', {
+        podName,
+        namespace,
+        deletionTimestamp,
+        deletionGracePeriodSeconds: resp.data?.metadata?.deletionGracePeriodSeconds,
+      });
+      return true;
+    }
+    logger.info('k8sLifecycle: pod is not marked for deletion at startup', { podName, namespace });
+    return false;
+  } catch (err: any) {
+    logger.warn('k8sLifecycle: pod-deletion check failed (non-fatal — continuing normal startup)', {
+      error: err?.message || String(err),
+      status: err?.response?.status,
+    });
+    return false; // fail open
+  }
+}


### PR DESCRIPTION
## Summary
Permanent fix for the SIGTERM-during-ContainerCreating race. When K8s sets
a pod's deletionTimestamp while the image is still pulling, kubelet sends
SIGTERM to a not-yet-existing PID 1 — the signal is silently dropped and
kubelet does NOT re-send. The bot then runs normally for the full 3h
`terminationGracePeriodSeconds`, picking up Redis jobs the whole time. HPA
`stabilizationWindowSeconds: 600` mitigates the HPA-induced case; this
closes the rest.

## Fix
At startup, the bot now queries the K8s API for its own pod metadata. If
`deletionTimestamp` is set, it immediately calls
`initiateGracefulShutdown()` (existing function). Fail-open: any error in
the check (missing service account, K8s API hiccup, etc.) lets normal
startup proceed.

## Requires (matching PR in screenapp-kubernetes repo)
- Downward API env vars `POD_NAME` and `POD_NAMESPACE` on the deployment

## Test plan
- [ ] Local: app starts normally when `POD_NAME`/`POD_NAMESPACE` unset
(logs "skipping pod-deletion check") and Redis consumer activates as usual.
- [ ] Staging: rollout-restart a pod, kubectl delete the new pod while it's
 ContainerCreating. New replacement pod should log `pod is already marked
for deletion at startup` and exit cleanly within seconds — not hang for 3h.